### PR TITLE
Add a better onboarding experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Resend with Node.js
 
+[![](https://badgen.net/badge/Run%20with%20/VS%20Code/5B3ADF?icon=https://runme.dev/img/logo.svg)](https://runme.dev/api/runme?repository=git@github.com:resendlabs/resend-node-example.git)
+
 This example shows how to use Resend with [Node.js](https://nodejs.org).
 
 ## Prerequisites
@@ -11,21 +13,42 @@ To get the most out of this guide, you’ll need to:
 
 ## Instructions
 
-1. Replace `re_123456789` on `index.ts` with your API key.
+1. Install dependencies
+2. Set Resend API Key
+3. Send an email!
 
-2. Install dependencies:
+## 1. Install dependencies
 
-  ```sh
+Using npm
+
+```sh { name=install-npm }
 npm install
-# or
+```
+
+Using yarn
+
+```sh { name=install-yarn }
 yarn
-  ```
+```
 
-3. Execute the following command:
+## 2. Set API Key
 
-  ```sh
+```sh { name=set-api-key interactive=false }
+export RESEND_API_KEY=Resend API Key
+echo 'Api Key Added'
+```
+
+## 2. Send an email
+
+```sh { name=send-email }
 npm run dev
-  ```
+```
+
+Open the dashboard logs to visualize your email
+
+```sh { name=open-dashboard background=false interactive=false }
+open https://resend.com/logs
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ export RESEND_API_KEY=Resend API Key
 echo 'Api Key Added'
 ```
 
-## 2. Send an email
+## 3. Send an email
 
 ```sh { name=send-email }
 npm run dev

--- a/index.ts
+++ b/index.ts
@@ -1,7 +1,7 @@
 import { Resend } from 'resend';
-const resend = new Resend('re_123456789');
+const resend = new Resend(process.env['RESEND_API_KEY']);
 
-(async function() {
+(async function () {
   try {
     const data = await resend.emails.send({
       from: 'onboarding@resend.dev',


### PR DESCRIPTION
I'm a big fan of Resend; this PR updates the README to provide a superior onboarding experience.
It lets you clone the project with one click.
VS Code or CLI options to run the commands available.

TODO: 

- [ ]  If approved, we can reference that https://runme.dev/ is required to run the commands (optional)

Disclaimer: I'm a core contributor of Runme, although, Runme is not required to execute and follow this README file.

Via VS Code

![resend-vscode](https://github.com/resendlabs/resend-node-example/assets/4001529/301b9fd1-edd0-4480-ac80-eb4bc3622e44)

Via CLI

![resend-demo](https://github.com/resendlabs/resend-node-example/assets/4001529/3d3356a4-9c0a-461e-b0ea-8fd2adcad299)


